### PR TITLE
fix: update HelmRelease API version to v2

### DIFF
--- a/environments/core/tailscale-operator/helmrelease.yaml
+++ b/environments/core/tailscale-operator/helmrelease.yaml
@@ -7,7 +7,7 @@ spec:
   interval: 24h
   url: https://pkgs.tailscale.com/helmcharts
 ---
-apiVersion: helm.toolkit.fluxcd.io/v2beta1
+apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
   name: tailscale-operator


### PR DESCRIPTION
## Problem

Tailscale Operator deployment was failing with error:
```
no matches for kind "HelmRelease" in version "helm.toolkit.fluxcd.io/v2beta1"
```

## Root Cause

FluxCD v2.7+ upgraded the HelmRelease API from `v2beta1` to `v2`.

## Solution

Updated `environments/core/tailscale-operator/helmrelease.yaml`:
- Changed: `helm.toolkit.fluxcd.io/v2beta1` → `helm.toolkit.fluxcd.io/v2`

## Verification

```bash
# Cluster supports v2
kubectl api-resources | grep helmrelease
# helmreleases  hr  helm.toolkit.fluxcd.io/v2  true  HelmRelease

# Build test
kubectl kustomize environments/core/tailscale-operator
```

## Impact

After merge:
- ✅ Tailscale Operator will deploy successfully
- ✅ Portainer Agent will deploy (depends on Tailscale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)