### PR TITLE
fix: separate Longhorn UI ClusterIP and Tailscale LoadBalancer

### DIFF
--- a/environments/core/longhorn/helmrelease.yaml
+++ b/environments/core/longhorn/helmrelease.yaml
@@ -34,11 +34,7 @@ spec:
       defaultClassReplicaCount: "2"
     service:
       ui:
-        type: LoadBalancer
-        loadBalancerClass: tailscale
-        annotations:
-          tailscale.com/expose: "true"
-          tailscale.com/hostname: "longhorn-ui"
+        type: ClusterIP
     defaultSettings:
       backupTarget: ""
       defaultReplicaCount: "2"

--- a/environments/core/longhorn/service-tailscale.yaml
+++ b/environments/core/longhorn/service-tailscale.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: longhorn-frontend-tailscale
+  namespace: longhorn-system
+  annotations:
+    tailscale.com/expose: "true"
+    tailscale.com/hostname: "longhorn-ui"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: tailscale
+  selector:
+    app: longhorn-ui
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http


### PR DESCRIPTION
## Summary
Fixed Longhorn deployment failure and unblocked dependent operators by separating the UI ClusterIP service from Tailscale LoadBalancer service.

## Problem
- Longhorn HelmRelease was failing with timeout error
- Helm waited 5 minutes for LoadBalancer EXTERNAL-IP that Tailscale never provides
- Redis and PostgreSQL operators couldn't deploy due to failed Longhorn dependency

## Changes
- **[environments/core/longhorn/helmrelease.yaml](environments/core/longhorn/helmrelease.yaml)**: Restored `service.ui.type` to `ClusterIP`
- **[environments/core/longhorn/service-tailscale.yaml](environments/core/longhorn/service-tailscale.yaml)**: Created separate Tailscale LoadBalancer service

## Benefits
- ✅ Helm deployment succeeds without timeout
- ✅ Longhorn UI still accessible via Tailscale at `https://longhorn-ui.{tailnet}.ts.net`
- ✅ Cleaner separation of concerns
- ✅ Redis and PostgreSQL operators can now deploy

## Test Plan
- [ ] Verify Longhorn HelmRelease deploys successfully
- [ ] Confirm `longhorn-frontend` service is ClusterIP
- [ ] Confirm `longhorn-frontend-tailscale` service is LoadBalancer with Tailscale
- [ ] Verify Longhorn UI accessible via Tailscale
- [ ] Verify Redis and PostgreSQL operators deploy successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)