### PR TITLE
fix: enable cert-manager deployment

### DIFF
--- a/clusters/us-west/core/kustomization.yaml
+++ b/clusters/us-west/core/kustomization.yaml
@@ -10,4 +10,4 @@ resources:
   - longhorn.yaml
   - cloudnative-pg.yaml
   - redis-operator.yaml
-  # - cert-manager.yaml
+  - cert-manager.yaml


### PR DESCRIPTION
## Problem
cert-manager was merged in PR #8 but not activated in the kustomization, so it never deployed.

## Root Cause
`cert-manager.yaml` was commented out in `clusters/us-west/core/kustomization.yaml`

## Solution
Uncommented the cert-manager resource to enable deployment.

## Changes
```diff
resources:
  - longhorn.yaml
  - cloudnative-pg.yaml
  - redis-operator.yaml
- # - cert-manager.yaml
+ - cert-manager.yaml
```

## Expected Result
After merge, FluxCD will deploy:
- ✅ cert-manager v1.16.2 Helm chart
- ✅ Cloudflare API token secret (SOPS encrypted)
- ✅ Let's Encrypt Production ClusterIssuer
- ✅ Automatic TLS certificate management

## Verification
```bash
# After merge, check deployment
flux get kustomizations cert-manager
kubectl get helmrelease -n cert-manager
kubectl get clusterissuer letsencrypt-production
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)