### PR TITLE
fix: add missing kustomization.yaml for cert-manager

### DIFF
--- a/environments/core/cert-manager/kustomization.yaml
+++ b/environments/core/cert-manager/kustomization.yaml
@@ -1,0 +1,9 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - helmrelease.yaml
+  - cloudflare-api-token.sops.yaml
+  - clusterissuer-production.yaml


### PR DESCRIPTION
## Problem
cert-manager was not deploying despite being enabled in the cluster kustomization. Error:
```
ClusterIssuer/letsencrypt-production dry-run failed: 
no matches for kind "ClusterIssuer" in version "cert-manager.io/v1"
```

## Root Cause
**Missing `kustomization.yaml` in `environments/core/cert-manager/`**

Without this file, FluxCD couldn't discover resources to deploy:
- ❌ Only `namespace.yaml` was applied
- ❌ `helmrelease.yaml` (cert-manager CRDs) not deployed
- ❌ `cloudflare-api-token.sops.yaml` not deployed
- ❌ `clusterissuer-production.yaml` failed (no CRDs)

## Solution
Created [environments/core/cert-manager/kustomization.yaml](environments/core/cert-manager/kustomization.yaml):
```yaml
apiVersion: kustomize.config.k8s.io/v1beta1
kind: Kustomization

resources:
  - namespace.yaml
  - helmrelease.yaml
  - cloudflare-api-token.sops.yaml
  - clusterissuer-production.yaml
```

## Expected Result
After merge, FluxCD will deploy:
- ✅ cert-manager v1.16.2 Helm chart
- ✅ cert-manager CRDs (including ClusterIssuer)
- ✅ Cloudflare API token secret (SOPS encrypted)
- ✅ Let's Encrypt Production ClusterIssuer
- ✅ Automatic TLS certificate management

## Verification
```bash
# After merge, check deployment
flux get kustomizations cert-manager
kubectl get helmrelease -n cert-manager
kubectl get clusterissuer letsencrypt-production
kubectl get secret -n cert-manager cloudflare-api-token-secret
```

## Related
- Original PR: #8 (added cert-manager configuration)
- Enable PR: #10 (uncommented cert-manager in cluster kustomization)

🤖 Generated with [Claude Code](https://claude.com/claude-code)