### PR TITLE
fix: update cert-manager version to v1.19.0

### DIFF
--- a/environments/core/cert-manager/helmrelease.yaml
+++ b/environments/core/cert-manager/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: 1.16.2
+      version: v1.19.0
       sourceRef:
         kind: HelmRepository
         name: jetstack


### PR DESCRIPTION
Fixes version mismatch - updated from 1.16.2 to v1.19.0 to match infrastructure directory.