### PR TITLE
fix(cert-manager): Resolve deployment race condition and reconfigure

### DIFF
--- a/clusters/us-west/core/cert-manager-issuers.yaml
+++ b/clusters/us-west/core/cert-manager-issuers.yaml
@@ -13,5 +13,10 @@ spec:
     name: flux-system
   wait: true
   timeout: 5m
+  # This is the crucial part: wait for cert-manager to be ready first
   dependsOn:
     - name: cert-manager
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/environments/core/cert-manager/kustomization.yaml
+++ b/environments/core/cert-manager/kustomization.yaml
@@ -5,4 +5,3 @@ resources:
   - namespace.yaml
   - helmrepository.yaml
   - helmrelease.yaml
-  - issuers/


### PR DESCRIPTION
This commit resolves a race condition in the cert-manager deployment where the ClusterIssuer was being created before its CRD was available.