### PR TITLE
fix(cert-manager): Revert to HelmRepository and upgrade to v1.19.1

### DIFF
--- a/environments/core/cert-manager/helmrelease.yaml
+++ b/environments/core/cert-manager/helmrelease.yaml
@@ -9,18 +9,14 @@ spec:
   chart:
     spec:
       chart: cert-manager
+      version: v1.19.1
       sourceRef:
-        kind: OCIRepository
+        kind: HelmRepository
         name: cert-manager
         namespace: cert-manager
       interval: 12h
-  install:
-    crds: Create
-  upgrade:
-    crds: CreateReplace
   values:
-    crds:
-      enabled: true
+    installCRDs: true
 
     # Enable prometheus monitoring
     prometheus:

--- a/environments/core/cert-manager/helmrepository.yaml
+++ b/environments/core/cert-manager/helmrepository.yaml
@@ -1,11 +1,9 @@
 ---
 apiVersion: source.toolkit.fluxcd.io/v1beta2
-kind: OCIRepository
+kind: HelmRepository
 metadata:
   name: cert-manager
   namespace: cert-manager
 spec:
   interval: 24h
-  url: oci://quay.io/jetstack/charts
-  ref:
-    tag: v1.19.1
+  url: https://charts.jetstack.io

--- a/environments/core/cert-manager/kustomization.yaml
+++ b/environments/core/cert-manager/kustomization.yaml
@@ -3,5 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
-  - ocirepository.yaml
+  - helmrepository.yaml
   - helmrelease.yaml


### PR DESCRIPTION
This commit reverts the cert-manager deployment method from OCIRepository back to HelmRepository to ensure compatibility with the installed version of Flux.