### PR TITLE
fix(cloudflared): enforce http2 protocol

### DIFF
--- a/system/cloudflared/deployment.yaml
+++ b/system/cloudflared/deployment.yaml
@@ -22,6 +22,7 @@ spec:
             - tunnel
             # Points to the secret that contains the tunnel token
             - run
+            # Enforce http2 protocol to prevent connection timeouts caused by QUIC/UDP issues.
             - --protocol
             - http2
             - --token


### PR DESCRIPTION
This PR adds the --protocol http2 argument to the cloudflared deployment to prevent connection timeouts caused by QUIC/UDP issues.