### PR TITLE
feat: restore auto PR review trigger & rename command to @gemini

### DIFF
--- a/.github/workflows/gemini-dispatch.yml
+++ b/.github/workflows/gemini-dispatch.yml
@@ -10,6 +10,7 @@ on:
   pull_request:
     types:
       - "opened"
+      - "synchronize"
   issues:
     types:
       - "opened"
@@ -93,7 +94,7 @@ jobs:
             const request = process.env.REQUEST;
             core.setOutput('request', request);
 
-            if (eventType === 'pull_request.opened') {
+            if (eventType === 'pull_request.opened' || eventType === 'pull_request.synchronize') {
               core.setOutput('command', 'review');
             } else if (['issues.opened', 'issues.reopened'].includes(eventType)) {
               core.setOutput('command', 'triage');


### PR DESCRIPTION
Restoring the functionality to automatically trigger PR reviews on open (for non-forks). Also renaming the manual trigger command from @gemini-cli to @gemini for brevity, and ensuring GOOGLE_GEMINI_BASE_URL uses vars.