### PR TITLE
fix: grant contents write permission for gemini dispatch workflow

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -27,7 +27,7 @@ jobs:
     uses: simplelumine/gemini-lumine/.github/workflows/gemini-dispatch.yml@main
     secrets: inherit
     permissions:
-      contents: read
+      contents: write
       issues: write
       pull-requests: write
       id-token: write


### PR DESCRIPTION
The nested fix job in gemini-dispatch.yml requires contents write permission to create branches and commit code changes.