### PR TITLE
Fix litellm Redis connection host

### DIFF
--- a/clusters/production/workloads/litellm-patch.yaml
+++ b/clusters/production/workloads/litellm-patch.yaml
@@ -32,7 +32,7 @@ spec:
 
     extraEnvVars:
       - name: REDIS_HOST
-        value: "redis-ha-leader.redis.svc.cluster.local"
+        value: "redis-ha-master.redis.svc.cluster.local"
       - name: REDIS_PORT
         value: "6379"
 


### PR DESCRIPTION
Corrected the `REDIS_HOST` environment variable in `clusters/production/workloads/litellm-patch.yaml` to address the connection error reported by the user. The service `redis-ha-leader` was invalid; it has been replaced with `redis-ha-master`, which is the correct service for the Redis master node in the `redis` namespace.

---
*PR created automatically by Jules for task [10994318379035685279](https://jules.google.com/task/10994318379035685279) started by @simplelumine*